### PR TITLE
make in-memory bucket add thread-safe

### DIFF
--- a/memory/memory.go
+++ b/memory/memory.go
@@ -1,8 +1,10 @@
 package memory
 
 import (
-	"github.com/Clever/leakybucket"
+	"sync"
 	"time"
+
+	"github.com/Clever/leakybucket"
 )
 
 type bucket struct {
@@ -10,6 +12,7 @@ type bucket struct {
 	remaining uint
 	reset     time.Time
 	rate      time.Duration
+	mutex     sync.Mutex
 }
 
 func (b *bucket) Capacity() uint {
@@ -28,6 +31,8 @@ func (b *bucket) Reset() time.Time {
 
 // Add to the bucket.
 func (b *bucket) Add(amount uint) (leakybucket.BucketState, error) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
 	if time.Now().After(b.reset) {
 		b.reset = time.Now().Add(b.rate)
 		b.remaining = b.capacity

--- a/memory/memory_test.go
+++ b/memory/memory_test.go
@@ -14,6 +14,10 @@ func TestAdd(t *testing.T) {
 	test.AddTest(New())(t)
 }
 
+func TestAddResetTest(t *testing.T) {
+	test.AddResetTest(New())(t)
+}
+
 func TestThreadSafeAdd(t *testing.T) {
 	test.ThreadSafeAddTest(New())(t)
 }


### PR DESCRIPTION
The test of this was not rigorous enough, so the in-memory leaky bucket was not actually thread-safe.