### PR TITLE
Fix data races

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,11 @@ include golang.mk
 SHELL := /bin/bash
 PKG := github.com/Clever/leakybucket
 PKGS := $(shell go list ./...)
-$(eval $(call golang-version-check,1.6))
+$(eval $(call golang-version-check,'1.5\|1.6'))
 
 export REDIS_URL ?= localhost:6379
 
 test: $(PKGS)
-$(PKGS): golang-test-all-deps
+$(PKGS): golang-test-all-strict-deps
 	go get -d -t $@
-	$(call golang-test-all,$@)
+	$(call golang-test-all-strict,$@)


### PR DESCRIPTION
- Protects `capacity`, `remaining` and `reset` from data races.
- Upgrades from general to strict testing

before:
```
> make
go get -d -t github.com/Clever/leakybucket
FORMATTING github.com/Clever/leakybucket...
LINTING github.com/Clever/leakybucket...
VETTING github.com/Clever/leakybucket...
TESTING github.com/Clever/leakybucket...
?       github.com/Clever/leakybucket   [no test files]
go get -d -t github.com/Clever/leakybucket/memory
FORMATTING github.com/Clever/leakybucket/memory...
LINTING github.com/Clever/leakybucket/memory...
VETTING github.com/Clever/leakybucket/memory...
TESTING github.com/Clever/leakybucket/memory...
=== RUN   TestCreate
--- PASS: TestCreate (0.00s)
=== RUN   TestAdd
--- PASS: TestAdd (0.00s)
=== RUN   TestAddResetTest
--- PASS: TestAddResetTest (0.00s)
=== RUN   TestThreadSafeAdd
--- PASS: TestThreadSafeAdd (0.02s)
=== RUN   TestReset
--- PASS: TestReset (0.00s)
=== RUN   TestFindOrCreate
--- PASS: TestFindOrCreate (2.00s)
=== RUN   TestBucketInstanceConsistencyTest
--- PASS: TestBucketInstanceConsistencyTest (4.00s)
PASS
ok      github.com/Clever/leakybucket/memory    7.038s
go get -d -t github.com/Clever/leakybucket/redis
FORMATTING github.com/Clever/leakybucket/redis...
LINTING github.com/Clever/leakybucket/redis...
VETTING github.com/Clever/leakybucket/redis...
TESTING github.com/Clever/leakybucket/redis...
=== RUN   TestInvalidHost
--- PASS: TestInvalidHost (0.00s)
=== RUN   TestCreate
--- PASS: TestCreate (0.00s)
=== RUN   TestAdd
--- PASS: TestAdd (0.00s)
=== RUN   TestThreadSafeAdd
--- SKIP: TestThreadSafeAdd (0.00s)
    redis_test.go:52:
=== RUN   TestReset
--- PASS: TestReset (0.01s)
=== RUN   TestFindOrCreate
--- PASS: TestFindOrCreate (2.00s)
=== RUN   TestBucketInstanceConsistencyTest
--- PASS: TestBucketInstanceConsistencyTest (4.01s)
=== RUN   TestFastAccess
==================
WARNING: DATA RACE
Write by goroutine 29:
  github.com/Clever/leakybucket/redis.(*bucket).Add()
      /home/vagrant/go/src/github.com/Clever/leakybucket/redis/redis.go:66 +0x124e
  github.com/Clever/leakybucket/redis.TestFastAccess.func1()
      /home/vagrant/go/src/github.com/Clever/leakybucket/redis/redis_test.go:88 +0xb2

Previous write by goroutine 26:
  github.com/Clever/leakybucket/redis.(*bucket).Add()
      /home/vagrant/go/src/github.com/Clever/leakybucket/redis/redis.go:66 +0x124e
  github.com/Clever/leakybucket/redis.TestFastAccess.func1()
      /home/vagrant/go/src/github.com/Clever/leakybucket/redis/redis_test.go:88 +0xb2

Goroutine 29 (running) created at:
  github.com/Clever/leakybucket/redis.TestFastAccess()
      /home/vagrant/go/src/github.com/Clever/leakybucket/redis/redis_test.go:91 +0x2b0
  testing.tRunner()
      /tmp/workdir/go/src/testing/testing.go:456 +0xdc

Goroutine 26 (running) created at:
  github.com/Clever/leakybucket/redis.TestFastAccess()
      /home/vagrant/go/src/github.com/Clever/leakybucket/redis/redis_test.go:91 +0x2b0
  testing.tRunner()
      /tmp/workdir/go/src/testing/testing.go:456 +0xdc
==================
==================
WARNING: DATA RACE
Write by goroutine 23:
  github.com/Clever/leakybucket/redis.(*bucket).updateOldReset()
      /home/vagrant/go/src/github.com/Clever/leakybucket/redis/redis.go:49 +0x43a
  github.com/Clever/leakybucket/redis.(*bucket).Add()
      /home/vagrant/go/src/github.com/Clever/leakybucket/redis/redis.go:86 +0xd65
  github.com/Clever/leakybucket/redis.TestFastAccess.func1()
      /home/vagrant/go/src/github.com/Clever/leakybucket/redis/redis_test.go:88 +0xb2

Previous read by goroutine 37:
  github.com/Clever/leakybucket/redis.(*bucket).updateOldReset()
      /home/vagrant/go/src/github.com/Clever/leakybucket/redis/redis.go:38 +0x63
  github.com/Clever/leakybucket/redis.(*bucket).Add()
      /home/vagrant/go/src/github.com/Clever/leakybucket/redis/redis.go:86 +0xd65
  github.com/Clever/leakybucket/redis.TestFastAccess.func1()
      /home/vagrant/go/src/github.com/Clever/leakybucket/redis/redis_test.go:88 +0xb2

Goroutine 23 (running) created at:
  github.com/Clever/leakybucket/redis.TestFastAccess()
      /home/vagrant/go/src/github.com/Clever/leakybucket/redis/redis_test.go:91 +0x2b0
  testing.tRunner()
      /tmp/workdir/go/src/testing/testing.go:456 +0xdc

Goroutine 37 (running) created at:
  github.com/Clever/leakybucket/redis.TestFastAccess()
      /home/vagrant/go/src/github.com/Clever/leakybucket/redis/redis_test.go:91 +0x2b0
  testing.tRunner()
      /tmp/workdir/go/src/testing/testing.go:456 +0xdc
==================
--- PASS: TestFastAccess (0.05s)
PASS
Found 2 data race(s)
exit status 66
FAIL    github.com/Clever/leakybucket/redis     7.089s
make: *** [github.com/Clever/leakybucket/redis] Error 1
```


after:
```
> make
go get -d -t github.com/Clever/leakybucket
FORMATTING github.com/Clever/leakybucket...
LINTING github.com/Clever/leakybucket...
VETTING github.com/Clever/leakybucket...
TESTING github.com/Clever/leakybucket...
?       github.com/Clever/leakybucket   [no test files]
go get -d -t github.com/Clever/leakybucket/memory
FORMATTING github.com/Clever/leakybucket/memory...
LINTING github.com/Clever/leakybucket/memory...
VETTING github.com/Clever/leakybucket/memory...
TESTING github.com/Clever/leakybucket/memory...
=== RUN   TestCreate
--- PASS: TestCreate (0.00s)
=== RUN   TestAdd
--- PASS: TestAdd (0.00s)
=== RUN   TestAddResetTest
--- PASS: TestAddResetTest (0.00s)
=== RUN   TestThreadSafeAdd
--- PASS: TestThreadSafeAdd (0.02s)
=== RUN   TestReset
--- PASS: TestReset (0.00s)
=== RUN   TestFindOrCreate
--- PASS: TestFindOrCreate (2.00s)
=== RUN   TestBucketInstanceConsistencyTest
--- PASS: TestBucketInstanceConsistencyTest (4.00s)
PASS
ok      github.com/Clever/leakybucket/memory    7.034s
go get -d -t github.com/Clever/leakybucket/redis
FORMATTING github.com/Clever/leakybucket/redis...
LINTING github.com/Clever/leakybucket/redis...
VETTING github.com/Clever/leakybucket/redis...
TESTING github.com/Clever/leakybucket/redis...
=== RUN   TestInvalidHost
--- PASS: TestInvalidHost (0.00s)
=== RUN   TestCreate
--- PASS: TestCreate (0.00s)
=== RUN   TestAdd
--- PASS: TestAdd (0.00s)
=== RUN   TestThreadSafeAdd
--- SKIP: TestThreadSafeAdd (0.00s)
    redis_test.go:52:
=== RUN   TestReset
--- PASS: TestReset (0.01s)
=== RUN   TestFindOrCreate
--- PASS: TestFindOrCreate (2.00s)
=== RUN   TestBucketInstanceConsistencyTest
--- PASS: TestBucketInstanceConsistencyTest (4.01s)
=== RUN   TestFastAccess
--- PASS: TestFastAccess (0.03s)
PASS
ok      github.com/Clever/leakybucket/redis     7.070s
go get -d -t github.com/Clever/leakybucket/test
FORMATTING github.com/Clever/leakybucket/test...
LINTING github.com/Clever/leakybucket/test...
VETTING github.com/Clever/leakybucket/test...
TESTING github.com/Clever/leakybucket/test...
?       github.com/Clever/leakybucket/test      [no test files]
```