### PR TITLE
Add read timeout for Redis ops

### DIFF
--- a/redis/redis.go
+++ b/redis/redis.go
@@ -130,6 +130,8 @@ func (s *Storage) Create(name string, capacity uint, rate time.Duration) (leakyb
 
 // New initializes the connection to redis.
 func New(network, address string) (*Storage, error) {
+	// If we find we need to change this timeout per application, we may want to expose
+	// this as an extra config option
 	timeout := time.Duration(5000 * millisecond) // 5 seconds
 	s := &Storage{
 		pool: redis.NewPool(func() (redis.Conn, error) {

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -135,7 +135,7 @@ func New(network, address string) (*Storage, error) {
 	timeout := time.Duration(5000 * millisecond) // 5 seconds
 	s := &Storage{
 		pool: redis.NewPool(func() (redis.Conn, error) {
-			return redis.Dial(network, address, redis.DialReadTimeout(timeout))
+			return redis.Dial(network, address, redis.DialReadTimeout(timeout), redis.DialWriteTimeout(timeout))
 		}, 5)}
 	// When using a connection pool, you only get connection errors while trying to send commands.
 	// Try to PING so we can fail-fast in the case of invalid address.

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -130,9 +130,10 @@ func (s *Storage) Create(name string, capacity uint, rate time.Duration) (leakyb
 
 // New initializes the connection to redis.
 func New(network, address string) (*Storage, error) {
+	timeout := time.Duration(5000 * millisecond) // 5 seconds
 	s := &Storage{
 		pool: redis.NewPool(func() (redis.Conn, error) {
-			return redis.Dial(network, address)
+			return redis.Dial(network, address, redis.DialReadTimeout(timeout))
 		}, 5)}
 	// When using a connection pool, you only get connection errors while trying to send commands.
 	// Try to PING so we can fail-fast in the case of invalid address.


### PR DESCRIPTION
**JIRA**
https://clever.atlassian.net/browse/INFRA-3241

**Overview**
For flare-631, we saw that Sphinx wasn't acting as a passthrough proxy on errors even though we configured it as such because we weren't returning errors. This change causes reads slower than 5 seconds to error.

Note: this works because we do not use any operations that block on the server. If we did, we would need to have extra handling for each of those server blocking operations.

Operations we use:
* GET
* PTTL
* PING
* INCRBY
* PEXPIRE

Related documentation:
* https://godoc.org/github.com/garyburd/redigo/redis#Dial
* https://godoc.org/github.com/garyburd/redigo/redis#DialReadTimeout