### PR TITLE
Add TTLs to DynamoDB implementation

### DIFF
--- a/dynamodb/bucket_test.go
+++ b/dynamodb/bucket_test.go
@@ -3,6 +3,7 @@ package dynamodb
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/Clever/leakybucket/test"
 
@@ -40,19 +41,10 @@ func testStorage(t *testing.T) *Storage {
 	deleteTable(db)
 	err = createTable(db)
 	require.NoError(t, err)
-	storage, err := New(table, s)
+	storage, err := New(table, s, 10*time.Second)
 	require.NoError(t, err)
 
 	return storage
-}
-
-func TestNoTable(t *testing.T) {
-	session, err := session.NewSession(&aws.Config{
-		Endpoint: aws.String(os.Getenv("AWS_DYNAMO_ENDPOINT")),
-	})
-	require.NoError(t, err)
-	_, err = New("doesntmatter", session)
-	require.Error(t, err)
 }
 
 func TestCreate(t *testing.T) {
@@ -77,4 +69,50 @@ func TestFindOrCreate(t *testing.T) {
 
 func TestBucketInstanceConsistencyTest(t *testing.T) {
 	test.BucketInstanceConsistencyTest(testStorage(t))(t)
+}
+
+// package specific tests
+func TestNoTable(t *testing.T) {
+	session, err := session.NewSession(&aws.Config{
+		Endpoint: aws.String(os.Getenv("AWS_DYNAMO_ENDPOINT")),
+	})
+	require.NoError(t, err)
+	_, err = New("doesntmatter", session, 10*time.Second)
+	require.Error(t, err)
+}
+
+// TestBucketTTL makes sure the TTL field is being set correctly for dynamodb. The tricky part is
+// the actual deletion of the bucket is non-deterministic so there are two success modes:
+// - the bucket has been deleted -> we should get an `errBucketNotFound`
+// - the bucket has not been deleted -> the TTL field should be set to a time before now
+func TestBucketTTL(t *testing.T) {
+	s := testStorage(t)
+	s.db.ttl = time.Second
+
+	_, err := s.db.ddb.UpdateTimeToLive(&dynamodb.UpdateTimeToLiveInput{
+		TableName: aws.String(s.db.tableName),
+		TimeToLiveSpecification: &dynamodb.TimeToLiveSpecification{
+			AttributeName: aws.String("_ttl"),
+			Enabled:       aws.Bool(true),
+		},
+	})
+	require.NoError(t, err)
+	time.Sleep(time.Second)
+
+	bucket, err := s.Create("testbucket", 5, time.Second)
+	require.NoError(t, err)
+
+	time.Sleep(s.db.ttl + 10*time.Second)
+	dbBucket, err := s.db.bucket("testbucket")
+	if err == nil {
+		t.Log("bucket not yet deleted. TTL: ", dbBucket.TTL)
+		require.NotNil(t, dbBucket)
+		require.True(t, dbBucket.TTL.Before(time.Now()))
+	} else {
+		t.Log("bucket deleted")
+		require.Equal(t, errBucketNotFound, err)
+	}
+
+	_, err = bucket.Add(1)
+	require.NoError(t, err)
 }

--- a/dynamodb/db.go
+++ b/dynamodb/db.go
@@ -20,6 +20,7 @@ var (
 type bucketDB struct {
 	ddb       dynamodbiface.DynamoDBAPI
 	tableName string
+	ttl       time.Duration
 }
 
 type ddbBucketStatePrimaryKey struct {
@@ -47,8 +48,6 @@ func (d ddbBucketStatePrimaryKey) KeySchema() []*dynamodb.KeySchemaElement {
 // ddbBucket implements the db interface using dynamodb as the backend
 type ddbBucket struct {
 	ddbBucketStatePrimaryKey
-	// Value is the sum of all increments in the current sliding window for the bucket
-	Value uint `dynamodbav:"value"`
 	// Expiration indicates when the current rate limit expires. We opt not to use DyanamoDB TTLs
 	// because they don't have strong deletion guarantees.
 	// https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/howitworks-ttl.html
@@ -56,18 +55,25 @@ type ddbBucket struct {
 	// which an item truly gets deleted after expiration is specific to the nature of the workload
 	// and the size of the table."
 	Expiration time.Time `dynamodbav:"expiration,unixtime"`
+	// Value is the sum of all increments in the current sliding window for the bucket
+	Value uint `dynamodbav:"value"`
 	// Version is an internal field used to control flushing/draining the Value field concurrently
 	Version uint `dynamodbav:"version"`
+	// TTL is an internal attribute to define how long the item will live in dynamodb prior to being
+	// set for removal. This TTL mechanism is only used for good hygiene to ensure we don't leave
+	// unused buckets in the database forever
+	TTL time.Time `dynamodbav:"_ttl,unixtime"`
 }
 
-func newDDBBucket(name string, expiration time.Time) ddbBucket {
+func newDDBBucket(name string, expiresIn time.Duration, ttl time.Duration) ddbBucket {
 	return ddbBucket{
 		ddbBucketStatePrimaryKey: ddbBucketStatePrimaryKey{
 			Name: name,
 		},
+		Expiration: time.Now().Add(expiresIn),
 		Value:      0,
-		Expiration: expiration,
 		Version:    0,
+		TTL:        time.Now().Add(ttl),
 	}
 }
 
@@ -113,7 +119,16 @@ func (db bucketDB) bucket(name string) (*ddbBucket, error) {
 	return decodeBucket(res.Item)
 }
 
-func (db bucketDB) createOrFindBucket(bucket ddbBucket) (*ddbBucket, error) {
+func (db bucketDB) findOrCreateBucket(name string, expiresIn time.Duration) (*ddbBucket, error) {
+	dbBucket, err := db.bucket(name)
+	if err == nil {
+		return dbBucket, nil
+	} else if err != errBucketNotFound {
+		return nil, err
+	}
+
+	// otherwise create the bucket
+	bucket := newDDBBucket(name, expiresIn, db.ttl)
 	data, err := encodeBucket(bucket)
 	if err != nil {
 		return nil, err
@@ -130,7 +145,8 @@ func (db bucketDB) createOrFindBucket(bucket ddbBucket) (*ddbBucket, error) {
 		if !awsErr(err, dynamodb.ErrCodeConditionalCheckFailedException) {
 			return nil, err
 		}
-		// for existing buckets simply fetch
+		// insane edge case because we know we can have multiple consumers
+		// for existing buckets simply re-fetch
 		return db.bucket(bucket.Name)
 	}
 
@@ -170,20 +186,15 @@ func (db bucketDB) incrementBucketValue(name string, amount, capacity uint) (*dd
 }
 
 // resetBucket will reset the bucket's value to 0 iff the versions match
-func (db bucketDB) resetBucket(bucket ddbBucket, expiration time.Time) (*ddbBucket, error) {
+func (db bucketDB) resetBucket(bucket ddbBucket, expiresIn time.Duration) (*ddbBucket, error) {
 	// dbMaxVersion is an arbitrary constant to prevent the version field from overflowing
 	var dbMaxVersion uint = 2 << 28
 	newVersion := bucket.Version + 1
 	if newVersion > dbMaxVersion {
 		newVersion = 0
 	}
-
-	updatedBucket := ddbBucket{
-		ddbBucketStatePrimaryKey: bucket.ddbBucketStatePrimaryKey,
-		Value:                    0,
-		Expiration:               expiration,
-		Version:                  newVersion,
-	}
+	updatedBucket := newDDBBucket(bucket.ddbBucketStatePrimaryKey.Name, expiresIn, db.ttl)
+	updatedBucket.Version = newVersion
 	data, err := encodeBucket(updatedBucket)
 	if err != nil {
 		return nil, err

--- a/dynamodb/db.go
+++ b/dynamodb/db.go
@@ -66,14 +66,15 @@ type ddbBucket struct {
 }
 
 func newDDBBucket(name string, expiresIn time.Duration, ttl time.Duration) ddbBucket {
+	now := time.Now()
 	return ddbBucket{
 		ddbBucketStatePrimaryKey: ddbBucketStatePrimaryKey{
 			Name: name,
 		},
-		Expiration: time.Now().Add(expiresIn),
+		Expiration: now.Add(expiresIn),
 		Value:      0,
 		Version:    0,
-		TTL:        time.Now().Add(ttl),
+		TTL:        now.Add(ttl),
 	}
 }
 


### PR DESCRIPTION
Expands on https://github.com/Clever/leakybucket/pull/34 by adding a TTL attribute on the objects to prevent leaving old buckets behind indefinitely. It is configured in `Storage.New`