### PR TITLE
Add semver auto releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,3 +20,4 @@ jobs:
     - run: ulimit -n 2560
     - run: make install_deps
     - run: make test
+    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then make release && $HOME/ci-scripts/circleci/github-release $GH_RELEASE_TOKEN release; fi;

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+**Overview:**
+
+**Merge Checklist:**
+- [ ] Update `VERSION` via semver

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,2 @@
+v1.0.0
+- v1.0.0: added dynamodb backed implementation


### PR DESCRIPTION
**Overview:**
This change is intended on making it easier and safer to pull in `leakybucket`

**Merge Checklist:**
- [x] Update `VERSION` via semver
- [x] Add `GH_RELEASE_TOKEN` to circleci -> used our public github release token