### PR TITLE
[INFRANG-6876] Upgrade to go 1.24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/go/src/github.com/Clever/leakybucket
     docker:
-    - image: cimg/go:1.21
+    - image: cimg/go:1.24
     - image: redis@sha256:858b1677143e9f8455821881115e276f6177221de1c663d0abef9b2fda02d065
     environment:
       GOPRIVATE: github.com/Clever/*

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ include golang.mk
 SHELL := /bin/bash
 PKG := github.com/Clever/leakybucket
 PKGS := $(shell go list ./... | grep -v /dynamodb | grep -v /vendor)
-$(eval $(call golang-version-check,1.13))
+$(eval $(call golang-version-check,1.24))
 
 export REDIS_URL ?= localhost:6379
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clever/leakybucket
 
-go 1.21
+go 1.24
 
 require (
 	github.com/aws/aws-sdk-go v1.29.31

--- a/golang.mk
+++ b/golang.mk
@@ -1,7 +1,7 @@
 # This is the default Clever Golang Makefile.
 # It is stored in the dev-handbook repo, github.com/Clever/dev-handbook
 # Please do not alter this file directly.
-GOLANG_MK_VERSION := 1.2.1
+GOLANG_MK_VERSION := 1.3.1
 
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
@@ -48,7 +48,7 @@ golang-ensure-curl-installed:
 # We pin its version because an update could add a new lint check which would make
 # previously passing tests start failing without changing our code.
 # this package is deprecated and frozen
-# Infra recomendation is to eventaully move to https://github.com/golangci/golangci-lint so don't fail on linting error for now
+# Infra recommendation is to eventually move to https://github.com/golangci/golangci-lint so don't fail on linting error for now
 GOLINT := $(GOPATH)/bin/golint
 $(GOLINT):
 	go install -mod=readonly golang.org/x/lint/golint@738671d3881b9731cc63024d5d88cf28db875626
@@ -159,17 +159,28 @@ $(call golang-vet,$(1))
 $(call golang-test-strict-cover,$(1))
 endef
 
-# golang-build: builds a golang binary. ensures CGO build is done during CI. This is needed to make a binary that works with a Docker alpine image.
+# golang-build: builds a golang binary
 # arg1: pkg path
 # arg2: executable name
 define golang-build
 @echo "BUILDING $(2)..."
-@if [ -z "$$CI" ]; then \
-	go build -o bin/$(2) $(1); \
-else \
-	echo "-> Building CGO binary"; \
-	CGO_ENABLED=0 go build -installsuffix cgo -o bin/$(2) $(1); \
-fi;
+@CGO_ENABLED=0 go build -o bin/$(2) $(1);
+endef
+
+# golang-debug-build: builds a golang binary with debugging capabilities
+# arg1: pkg path
+# arg2: executable name
+define golang-debug-build
+@echo "BUILDING $(2) FOR DEBUG..."
+@CGO_ENABLED=0 go build -gcflags="all=-N -l" -o bin/$(2) $(1);
+endef
+
+# golang-cgo-build: builds a golang binary with CGO
+# arg1: pkg path
+# arg2: executable name
+define golang-cgo-build
+@echo "BUILDING $(2) WITH CGO ..."
+@CGO_ENABLED=1 go build -installsuffix cgo -o bin/$(2) $(1);
 endef
 
 # golang-setup-coverage: set up the coverage file


### PR DESCRIPTION
<!-- This template should be used as a living PR template for future go migrations -->

# JIRA
https://clever.atlassian.net/browse/INFRANG-6876

# About
This PR upgrades this repo to Go version 1.24. See the [release notes](https://tip.golang.org/doc/go1.24) for full details.

It performs the following changes:
1. Upgrade the module to 1.24.
2. Upgrade the golang.mk file to the latest version.
3. Replaces any `tools.go` file with the new go.mod tools directive.
4. Updates any circle CI build images to 1.24.
5. Updates the go version check in the makefile.
6. Updates any debian docker images to a version with a glibc compatible with the CI build image.



#### New Go Vet Check
Go vet in 1.24 introduces a new check which catches non-constant format strings in calls to printf functions. This has a tendency to find bugs in existing code, however the fix is pretty strait forward should your CI begin to fail. You can see more details in the official issue https://github.com/golang/go/issues/60529. If your CI fails because of this, you may add an extra commit resolving the issue, then merge. The microplane script attempts to resolve as many of these cases as possible automatically.

# Testing
Go version upgrades have historically been extremely stable. The only exception has been incompatible glibc versions which have been tested for in workers before merging. All standard CI testing is also performed before merging.

# Problems Upgrading?
Checkout this [google doc](https://docs.google.com/document/d/1ctg3eT8zkKHXqsf7CCUBB77ERmEVMsyZoYAIxXm19hs/edit?usp=sharing) for knowledge sharing any problems you encounter during upgrades!
